### PR TITLE
Make scripts executable from anywhere in the system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 home
 workspace
+base-container_id.txt
 devel-container_id.txt
 release-container_id.txt
 has_gpu_support.txt
+*.tar.gz

--- a/autocomplete.me
+++ b/autocomplete.me
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+ROOT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+export PATH=$ROOT_DIR${PATH:+:${PATH}}
+
 complete -W  "$(ls startscripts | xargs) /bin/bash" ./deprecated_exec_in_devel.bash
 complete -W  "$(ls startscripts | xargs) /bin/bash" ./deprecated_exec_in_release.bash
 

--- a/docker_commands.bash
+++ b/docker_commands.bash
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-. ./settings.bash
+ROOT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. $ROOT_DIR/settings.bash
 
 DNSIP=$(nmcli dev show | grep 'IP4.DNS' | grep "\[1\]" | egrep -oe "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}" | head -n 1)
 
@@ -17,7 +18,7 @@ init_docker(){
     fi
 
     #detect if gpus command is supported and working from docker 19.03
-    GPUS_SETTINGS_FILE="has_gpu_support.txt"
+    GPUS_SETTINGS_FILE="$ROOT_DIR/has_gpu_support.txt"
     if [ ! -f $GPUS_SETTINGS_FILE ]; then
         touch $GPUS_SETTINGS_FILE
         docker run --gpus=all --rm $IMAGE_NAME > /dev/null
@@ -42,8 +43,8 @@ init_docker(){
 
     # check if a container from previous runs exist
     if [ "$(docker ps -a | grep $CONTAINER_NAME)" ]; then
-        #check if the local image is newer that the one the container was crested with
-        #generate_container saves the curretn id to a file
+        #check if the local image is newer that the one the container was created with
+        #generate_container saves the current id to a file
         echo "found existing container"
         if [ "$CURRENT_IMAGE_ID" = "$CONTAINER_IMAGE_ID" ]; then
             echo "using existent container"

--- a/exec.bash
+++ b/exec.bash
@@ -2,11 +2,12 @@
 
 xhost +local:root
 
-. ./docker_commands.bash
+ROOT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. $ROOT_DIR/docker_commands.bash
 
 
+### EVALUATE ARGUMENTS AND SET EXECMODE
 EXECMODE=$DEFAULT_EXECMODE
-
 if [ "$1" = "devel" ]; then
     echo "overriding default execmode $DEFAULT_EXECMODE to: devel"
     EXECMODE="devel"
@@ -24,35 +25,35 @@ if [ "$1" = "base" ]; then
     shift
 fi
 
+# set default argument
 if [ -z "$1" ]; then
     echo "No run argument given. Using /bin/bash as default"
     set -- "/bin/bash"
 fi
 
+### START EXECUTION
 if [ "$EXECMODE" == "base" ]; then
     # DOCKER_REGISTRY and WORKSPACE_DEVEL_IMAGE from settings.bash
     IMAGE_NAME=${BASE_REGISTRY:+${BASE_REGISTRY}/}$WORKSPACE_BASE_IMAGE
-    HOST_WORKSPACE=$(pwd)
-    mkdir -p $HOST_WORKSPACE/workspace
-    mkdir -p $HOST_WORKSPACE/home
+    mkdir -p $ROOT_DIR/workspace
+    mkdir -p $ROOT_DIR/home
     ADDITIONAL_DOCKER_MOUNT_ARGS=" \
-        -v $HOST_WORKSPACE/workspace/:/opt/workspace \
-        -v $HOST_WORKSPACE/home/:/home/devel \
-        -v $HOST_WORKSPACE/image_setup/02_devel_image/setup_workspace.bash:/opt/setup_workspace.bash
+        -v $ROOT_DIR/workspace/:/opt/workspace \
+        -v $ROOT_DIR/home/:/home/devel \
+        -v $ROOT_DIR/image_setup/02_devel_image/setup_workspace.bash:/opt/setup_workspace.bash
         "
 fi
 
 if [ "$EXECMODE" = "devel" ]; then
     # DOCKER_REGISTRY and WORKSPACE_DEVEL_IMAGE from settings.bash
     IMAGE_NAME=${DEVEL_REGISTRY:+${DEVEL_REGISTRY}/}$WORKSPACE_DEVEL_IMAGE
-    HOST_WORKSPACE=$(pwd)
     #in case the devel image is pulled, we need the create the folders here
-    mkdir -p $HOST_WORKSPACE/workspace
-    mkdir -p $HOST_WORKSPACE/home
+    mkdir -p $ROOT_DIR/workspace
+    mkdir -p $ROOT_DIR/home
     ADDITIONAL_DOCKER_MOUNT_ARGS=" \
-        -v $HOST_WORKSPACE/startscripts:/opt/startscripts \
-        -v $HOST_WORKSPACE/workspace/:/opt/workspace \
-        -v $HOST_WORKSPACE/home/:/home/devel \
+        -v $ROOT_DIR/startscripts:/opt/startscripts \
+        -v $ROOT_DIR/workspace/:/opt/workspace \
+        -v $ROOT_DIR/home/:/home/devel \
         "
 fi
 if [ "$EXECMODE" == "release" ]; then
@@ -75,12 +76,12 @@ INTERACTIVE=${INTERACTIVE:="true"}
 
 #get a md5 for the current folder used as container name suffix
 #(several checkouts  of this repo possible withtou interfering)
-FOLDER_MD5=$(echo $(pwd) | md5sum | cut -b 1-8)
+FOLDER_MD5=$(echo $ROOT_DIR | md5sum | cut -b 1-8)
 
 #use current folder name + devel + path md5 as container name
 #(several checkouts  of this repo possible withtout interfering)
-CONTAINER_NAME=${CONTAINER_NAME:="${PWD##*/}-$EXECMODE-$FOLDER_MD5"}
-CONTAINER_ID_FILENAME=$EXECMODE-container_id.txt
+CONTAINER_NAME=${CONTAINER_NAME:="${ROOT_DIR##*/}-$EXECMODE-$FOLDER_MD5"}
+CONTAINER_ID_FILENAME=$ROOT_DIR/$EXECMODE-container_id.txt
 
 echo
 echo -e "\e[32musing ${IMAGE_NAME%:*}:\e[4;33m${IMAGE_NAME#*:}\e[0m"

--- a/image_setup/01_base_images/init_user_id.bash
+++ b/image_setup/01_base_images/init_user_id.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# this scrit will be called by .bashrc
+# this script will be called by .bashrc
 
 # on initialization check if the UID of the rosuser user has to be changed:
 if [ "$NUID" -a ! -f /initialized_uid ]; then

--- a/stop.bash
+++ b/stop.bash
@@ -1,8 +1,9 @@
 #get a md5 for the curretn folder used as container name suffix
-#(several checkouts  of this repo possible withtou interfering)
-FOLDER_MD5=$(echo $(pwd) | md5sum | cut -b 1-8)
+#(several checkouts  of this repo possible without interfering)
+ROOT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+FOLDER_MD5=$(echo $ROOT_DIR | md5sum | cut -b 1-8)
 
-. ./settings.bash
+. $ROOT_DIR/settings.bash
 
 EXECMODE=$DEFAULT_EXECMODE
 
@@ -21,7 +22,7 @@ fi
 
 #use current folder name + $EXECMODE + path md5 as container name
 #(several checkouts  of this repo possible withtout interfering)
-CONTAINER_NAME="${PWD##*/}-$EXECMODE-$FOLDER_MD5"
+CONTAINER_NAME="${ROOT_DIR##*/}-$EXECMODE-$FOLDER_MD5"
 
 echo "stopping ${CONTAINER_NAME}"
 docker stop ${CONTAINER_NAME}


### PR DESCRIPTION
This allows for running ./exec.bash and ./stop.bash from anywhere. Workspace and other files (e.g. has_gou_support.txt etc.) are created in place.

The idea originated from making the source includes of relative scripts more robust. This however will be helpful for starting docker containers via other scripts or during startup.