### PR TITLE
less output, allow VERBOSE mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ devel-container_id.txt
 release-container_id.txt
 has_gpu_support.txt
 *.tar.gz
+/image_setup/04_save_release/autocomplete.me

--- a/docker_commands.bash
+++ b/docker_commands.bash
@@ -5,7 +5,6 @@ ROOT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 DNSIP=$(nmcli dev show | grep 'IP4.DNS' | grep "\[1\]" | egrep -oe "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}" | head -n 1)
 
-
 PRINT_WARNING=echo
 PRINT_INFO=echo
 PRINT_DEBUG=:
@@ -17,14 +16,12 @@ if [ "$VERBOSE" = true ] && [ "$SILENT" = true ]; then
 fi
 
 if [ "$VERBOSE" = true ]; then
-    PRINT_ERROR=echo
     PRINT_WARNING=echo
     PRINT_INFO=echo
     PRINT_DEBUG=echo
 fi
 
 if [ "$SILENT" = true ]; then
-    PRINT_ERROR=:
     PRINT_WARNING=:
     PRINT_INFO=:
     PRINT_DEBUG=:
@@ -80,7 +77,7 @@ init_docker(){
                 start_container_nonint $@
             fi
         else
-            $PRINT_INFO "image id is newer that container image id, removing old container:"
+            $PRINT_INFO "Image id is newer that container image id, removing old container: $CONTAINER_NAME"
             #stop the container in case it is running
             docker stop $CONTAINER_NAME  > /dev/null
             docker rm $CONTAINER_NAME  > /dev/null
@@ -108,7 +105,7 @@ generate_container(){
 
     #initial run exits no matter what due to entrypoint (user id settings)
     #/bin/bash will be default nonetheless when called later without command
-    docker run -ti $RUNTIME_ARG $DOCKER_RUN_ARGS $IMAGE_NAME || exit 1
+    docker run -ti $RUNTIME_ARG $DOCKER_RUN_ARGS -e PRINT_WARNING=${PRINT_WARNING} -e PRINT_INFO=${PRINT_INFO} -e PRINT_DEBUG=${PRINT_DEBUG} $IMAGE_NAME || exit 1
     # default container exists after initial run
 
     $PRINT_DEBUG "docker start $CONTAINER_NAME"
@@ -131,7 +128,7 @@ generate_container_nonint(){
     $PRINT_DEBUG "generating new non-interactive container with $@"
     echo $CURRENT_IMAGE_ID > $CONTAINER_ID_FILENAME
 
-    docker run -t $RUNTIME_ARG $DOCKER_RUN_ARGS $IMAGE_NAME $@
+    docker run -t $RUNTIME_ARG $DOCKER_RUN_ARGS -e PRINT_WARNING=${PRINT_WARNING} -e PRINT_INFO=${PRINT_INFO} -e PRINT_DEBUG=${PRINT_DEBUG} $IMAGE_NAME $@
     
     # default container exists after initial run
     start_container_nonint $@

--- a/docker_commands.bash
+++ b/docker_commands.bash
@@ -5,12 +5,30 @@ ROOT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 DNSIP=$(nmcli dev show | grep 'IP4.DNS' | grep "\[1\]" | egrep -oe "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}" | head -n 1)
 
-if [ "$VERBOSE" = true ]; then
-    PRINT_CMD=echo
-else
-    PRINT_CMD=:
+
+PRINT_WARNING=echo
+PRINT_INFO=echo
+PRINT_DEBUG=:
+
+if [ "$VERBOSE" = true ] && [ "$SILENT" = true ]; then
+    echo "Error: cannot be VERBOSE and SILENT at the same time"
+    echo "Edit the settings.bash accordingly or if not set there use unset VERBOSE or unset SILENT in your console"
+    exit 1
 fi
 
+if [ "$VERBOSE" = true ]; then
+    PRINT_ERROR=echo
+    PRINT_WARNING=echo
+    PRINT_INFO=echo
+    PRINT_DEBUG=echo
+fi
+
+if [ "$SILENT" = true ]; then
+    PRINT_ERROR=:
+    PRINT_WARNING=:
+    PRINT_INFO=:
+    PRINT_DEBUG=:
+fi
 
 
 init_docker(){
@@ -18,10 +36,10 @@ init_docker(){
     #detect if nvidia runtime is available
     RUNTIMES=$(docker info | grep "Runtimes:")
     if [[ $RUNTIMES == *"nvidia"* ]]; then
-        $PRINT_CMD "has nvidia runtime"
+        $PRINT_DEBUG "has nvidia runtime"
         RUNTIME_ARG="--runtime=nvidia"
     else
-        $PRINT_CMD "deprecated nvidia-docker2 hardware acceleration not available, testing newer docker --gpu setting"
+        $PRINT_DEBUG "deprecated nvidia-docker2 hardware acceleration not available, testing newer docker --gpu setting"
         RUNTIME_ARG=""
     fi
 
@@ -31,16 +49,16 @@ init_docker(){
         touch $GPUS_SETTINGS_FILE
         docker run --gpus=all --rm $IMAGE_NAME > /dev/null
         GPU_SUPPORTED=$?
-        $PRINT_CMD "this file contains the gegerated result of testing the docker --gpu setting, 0=enabled, 1=disabled" > $GPUS_SETTINGS_FILE
-        $PRINT_CMD $GPU_SUPPORTED >> $GPUS_SETTINGS_FILE        
+        echo "this file contains the gegerated result of testing the docker --gpu setting, 0=enabled, 1=disabled" > $GPUS_SETTINGS_FILE
+        echo $GPU_SUPPORTED >> $GPUS_SETTINGS_FILE        
     fi
     HAS_GPU_SUPPORT=$(tail -n1 $GPUS_SETTINGS_FILE)
 
     if [[ $HAS_GPU_SUPPORT = "0" ]]; then
-        $PRINT_CMD "docker supports --gpu setting, hardware acceleration enabled"
+        $PRINT_DEBUG "docker supports --gpu setting, hardware acceleration enabled"
         RUNTIME_ARG="--gpus all"
     else
-        $PRINT_CMD "hardware acceleration disabled"
+        $PRINT_WARNING "hardware acceleration disabled"
     fi
 
     if [ "$1" = "noninteractive" ]; then
@@ -53,16 +71,16 @@ init_docker(){
     if [ "$(docker ps -a | grep $CONTAINER_NAME)" ]; then
         #check if the local image is newer that the one the container was created with
         #generate_container saves the current id to a file
-        $PRINT_CMD "found existing container"
+        $PRINT_DEBUG "found existing container"
         if [ "$CURRENT_IMAGE_ID" = "$CONTAINER_IMAGE_ID" ]; then
-            $PRINT_CMD "using existent container"
+            $PRINT_DEBUG "using existing container"
             if [ "$INTERACTIVE" = "true" ]; then
                 start_container $@
             else
                 start_container_nonint $@
             fi
         else
-            $PRINT_CMD "image id is newer that container image id, removing old container:"
+            $PRINT_INFO "image id is newer that container image id, removing old container:"
             #stop the container in case it is running
             docker stop $CONTAINER_NAME  > /dev/null
             docker rm $CONTAINER_NAME  > /dev/null
@@ -73,7 +91,7 @@ init_docker(){
             fi
         fi
     else
-        $PRINT_CMD "inital run, no container exists"
+        $PRINT_DEBUG "inital run, no container exists"
         if [ "$INTERACTIVE" = "true" ]; then
             generate_container $@
         else
@@ -85,7 +103,7 @@ init_docker(){
 
 #generate container and start command given ad paramater
 generate_container(){
-    $PRINT_CMD "generating new container : $CONTAINER_NAME"
+    $PRINT_DEBUG "generating new container : $CONTAINER_NAME"
     echo $CURRENT_IMAGE_ID > $CONTAINER_ID_FILENAME
 
     #initial run exits no matter what due to entrypoint (user id settings)
@@ -93,25 +111,25 @@ generate_container(){
     docker run -ti $RUNTIME_ARG $DOCKER_RUN_ARGS $IMAGE_NAME || exit 1
     # default container exists after initial run
 
-    $PRINT_CMD "docker start $CONTAINER_NAME"
+    $PRINT_DEBUG "docker start $CONTAINER_NAME"
     docker start $CONTAINER_NAME  > /dev/null
-    $PRINT_CMD "running /opt/check_init_workspace.bash in $CONTAINER_NAME"
+    $PRINT_DEBUG "running /opt/check_init_workspace.bash in $CONTAINER_NAME"
     docker exec -ti $CONTAINER_NAME /opt/check_init_workspace.bash
-    $PRINT_CMD "running $@ in $CONTAINER_NAME"
+    $PRINT_DEBUG "running $@ in $CONTAINER_NAME"
     docker exec -ti $CONTAINER_NAME $@
 }
 
 #starts container with the param given in first run
 start_container(){
-    $PRINT_CMD "docker start $CONTAINER_NAME"
+    $PRINT_DEBUG "docker start $CONTAINER_NAME"
     docker start $CONTAINER_NAME > /dev/null
-    $PRINT_CMD "running $@ in $CONTAINER_NAME"
+    $PRINT_DEBUG "running $@ in $CONTAINER_NAME"
     docker exec -ti $CONTAINER_NAME $@
 }
 
 generate_container_nonint(){
-    $PRINT_CMD "generating new non-interactive container with $@"
-    $PRINT_CMD $CURRENT_IMAGE_ID > $CONTAINER_ID_FILENAME
+    $PRINT_DEBUG "generating new non-interactive container with $@"
+    echo $CURRENT_IMAGE_ID > $CONTAINER_ID_FILENAME
 
     docker run -t $RUNTIME_ARG $DOCKER_RUN_ARGS $IMAGE_NAME $@
     
@@ -121,6 +139,6 @@ generate_container_nonint(){
 
 #starts container with the param given in first run
 start_container_nonint(){
-    $PRINT_CMD "docker start non-interactive $CONTAINER_NAME"
+    $PRINT_DEBUG "docker start non-interactive $CONTAINER_NAME"
     docker start -a $CONTAINER_NAME
 }

--- a/docker_commands.bash
+++ b/docker_commands.bash
@@ -5,15 +5,23 @@ ROOT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 DNSIP=$(nmcli dev show | grep 'IP4.DNS' | grep "\[1\]" | egrep -oe "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}" | head -n 1)
 
+if [ "$VERBOSE" = true ]; then
+    PRINT_CMD=echo
+else
+    PRINT_CMD=:
+fi
+
+
+
 init_docker(){
 
     #detect if nvidia runtime is available
     RUNTIMES=$(docker info | grep "Runtimes:")
     if [[ $RUNTIMES == *"nvidia"* ]]; then
-        echo "has nvidia runtime"
+        $PRINT_CMD "has nvidia runtime"
         RUNTIME_ARG="--runtime=nvidia"
     else
-        echo "deprecated nvidia-docker2 hardware acceleration not available, testing newer docker --gpu setting"
+        $PRINT_CMD "deprecated nvidia-docker2 hardware acceleration not available, testing newer docker --gpu setting"
         RUNTIME_ARG=""
     fi
 
@@ -23,16 +31,16 @@ init_docker(){
         touch $GPUS_SETTINGS_FILE
         docker run --gpus=all --rm $IMAGE_NAME > /dev/null
         GPU_SUPPORTED=$?
-        echo "this file contains the gegerated result of testing the docker --gpu setting, 0=enabled, 1=disabled" > $GPUS_SETTINGS_FILE
-        echo $GPU_SUPPORTED >> $GPUS_SETTINGS_FILE        
+        $PRINT_CMD "this file contains the gegerated result of testing the docker --gpu setting, 0=enabled, 1=disabled" > $GPUS_SETTINGS_FILE
+        $PRINT_CMD $GPU_SUPPORTED >> $GPUS_SETTINGS_FILE        
     fi
     HAS_GPU_SUPPORT=$(tail -n1 $GPUS_SETTINGS_FILE)
 
     if [[ $HAS_GPU_SUPPORT = "0" ]]; then
-        echo "docker supports --gpu setting, hardware acceleration enabled"
+        $PRINT_CMD "docker supports --gpu setting, hardware acceleration enabled"
         RUNTIME_ARG="--gpus all"
     else
-        echo "hardware acceleration disabled"
+        $PRINT_CMD "hardware acceleration disabled"
     fi
 
     if [ "$1" = "noninteractive" ]; then
@@ -45,19 +53,19 @@ init_docker(){
     if [ "$(docker ps -a | grep $CONTAINER_NAME)" ]; then
         #check if the local image is newer that the one the container was created with
         #generate_container saves the current id to a file
-        echo "found existing container"
+        $PRINT_CMD "found existing container"
         if [ "$CURRENT_IMAGE_ID" = "$CONTAINER_IMAGE_ID" ]; then
-            echo "using existent container"
+            $PRINT_CMD "using existent container"
             if [ "$INTERACTIVE" = "true" ]; then
                 start_container $@
             else
                 start_container_nonint $@
             fi
         else
-            echo "image id is newer that container image id, removing old container:"
+            $PRINT_CMD "image id is newer that container image id, removing old container:"
             #stop the container in case it is running
-            docker stop $CONTAINER_NAME
-            docker rm $CONTAINER_NAME
+            docker stop $CONTAINER_NAME  > /dev/null
+            docker rm $CONTAINER_NAME  > /dev/null
             if [ "$INTERACTIVE" = "true" ]; then
                 generate_container $@
             else
@@ -65,7 +73,7 @@ init_docker(){
             fi
         fi
     else
-        echo "inital run, no container exists"
+        $PRINT_CMD "inital run, no container exists"
         if [ "$INTERACTIVE" = "true" ]; then
             generate_container $@
         else
@@ -77,7 +85,7 @@ init_docker(){
 
 #generate container and start command given ad paramater
 generate_container(){
-    echo "generating new container : $CONTAINER_NAME"
+    $PRINT_CMD "generating new container : $CONTAINER_NAME"
     echo $CURRENT_IMAGE_ID > $CONTAINER_ID_FILENAME
 
     #initial run exits no matter what due to entrypoint (user id settings)
@@ -85,25 +93,25 @@ generate_container(){
     docker run -ti $RUNTIME_ARG $DOCKER_RUN_ARGS $IMAGE_NAME || exit 1
     # default container exists after initial run
 
-    echo "docker start $CONTAINER_NAME"
-    docker start $CONTAINER_NAME
-    echo "running /opt/check_init_workspace.bash in $CONTAINER_NAME"
+    $PRINT_CMD "docker start $CONTAINER_NAME"
+    docker start $CONTAINER_NAME  > /dev/null
+    $PRINT_CMD "running /opt/check_init_workspace.bash in $CONTAINER_NAME"
     docker exec -ti $CONTAINER_NAME /opt/check_init_workspace.bash
-    echo "running $@ in $CONTAINER_NAME"
+    $PRINT_CMD "running $@ in $CONTAINER_NAME"
     docker exec -ti $CONTAINER_NAME $@
 }
 
 #starts container with the param given in first run
 start_container(){
-    echo "docker start $CONTAINER_NAME"
-    docker start $CONTAINER_NAME
-    echo "running $@ in $CONTAINER_NAME"
+    $PRINT_CMD "docker start $CONTAINER_NAME"
+    docker start $CONTAINER_NAME > /dev/null
+    $PRINT_CMD "running $@ in $CONTAINER_NAME"
     docker exec -ti $CONTAINER_NAME $@
 }
 
 generate_container_nonint(){
-    echo "generating new non-interactive container with $@"
-    echo $CURRENT_IMAGE_ID > $CONTAINER_ID_FILENAME
+    $PRINT_CMD "generating new non-interactive container with $@"
+    $PRINT_CMD $CURRENT_IMAGE_ID > $CONTAINER_ID_FILENAME
 
     docker run -t $RUNTIME_ARG $DOCKER_RUN_ARGS $IMAGE_NAME $@
     
@@ -113,6 +121,6 @@ generate_container_nonint(){
 
 #starts container with the param given in first run
 start_container_nonint(){
-    echo "docker start non-interactive $CONTAINER_NAME"
+    $PRINT_CMD "docker start non-interactive $CONTAINER_NAME"
     docker start -a $CONTAINER_NAME
 }

--- a/exec.bash
+++ b/exec.bash
@@ -1,33 +1,35 @@
 #!/bin/bash
 
-xhost +local:root
+#allow local connections of root (docker daemon) to the current users x server
+xhost +local:root > /dev/null
 
 ROOT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . $ROOT_DIR/docker_commands.bash
 
 
+
 ### EVALUATE ARGUMENTS AND SET EXECMODE
 EXECMODE=$DEFAULT_EXECMODE
 if [ "$1" = "devel" ]; then
-    echo "overriding default execmode $DEFAULT_EXECMODE to: devel"
+    $PRINT_CMD "overriding default execmode $DEFAULT_EXECMODE to: devel"
     EXECMODE="devel"
     shift
 fi
 if [ "$1" = "release" ]; then
-    echo "overriding default execmode $DEFAULT_EXECMODE to: release"
+    $PRINT_CMD "overriding default execmode $DEFAULT_EXECMODE to: release"
     EXECMODE="release"
     shift
 fi
 
 if [ "$1" = "base" ]; then
-    echo "overriding default execmode $DEFAULT_EXECMODE to: base"
+    $PRINT_CMD "overriding default execmode $DEFAULT_EXECMODE to: base"
     EXECMODE="base"
     shift
 fi
 
 # set default argument
 if [ -z "$1" ]; then
-    echo "No run argument given. Using /bin/bash as default"
+    $PRINT_CMD "No run argument given. Using /bin/bash as default"
     set -- "/bin/bash"
 fi
 
@@ -70,9 +72,9 @@ if [ "$EXECMODE" == "release" ]; then
 fi
 
 if [ "$DOCKER_REGISTRY_AUTOPULL" = true ]; then
-    echo
-    echo pulling image: $IMAGE_NAME
-    echo
+    $PRINT_CMD
+    $PRINT_CMD pulling image: $IMAGE_NAME
+    $PRINT_CMD
     docker pull $IMAGE_NAME
 fi
 
@@ -91,9 +93,9 @@ FOLDER_MD5=$(echo $ROOT_DIR | md5sum | cut -b 1-8)
 CONTAINER_NAME=${CONTAINER_NAME:="${ROOT_DIR##*/}-$EXECMODE-$FOLDER_MD5"}
 CONTAINER_ID_FILENAME=$ROOT_DIR/$EXECMODE-container_id.txt
 
-echo
-echo -e "\e[32musing ${IMAGE_NAME%:*}:\e[4;33m${IMAGE_NAME#*:}\e[0m"
-echo
+$PRINT_CMD
+$PRINT_CMD -e "\e[32musing ${IMAGE_NAME%:*}:\e[4;33m${IMAGE_NAME#*:}\e[0m"
+$PRINT_CMD
 
 
 
@@ -115,4 +117,5 @@ DOCKER_RUN_ARGS=" \
 
 init_docker $@
 
-xhost -local:root
+#remove permission for local connections of root (docker daemon) to the current users x server
+xhost -local:root > /dev/null

--- a/exec.bash
+++ b/exec.bash
@@ -11,25 +11,25 @@ ROOT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 ### EVALUATE ARGUMENTS AND SET EXECMODE
 EXECMODE=$DEFAULT_EXECMODE
 if [ "$1" = "devel" ]; then
-    $PRINT_CMD "overriding default execmode $DEFAULT_EXECMODE to: devel"
+    $PRINT_WARNING "overriding default execmode $DEFAULT_EXECMODE to: devel"
     EXECMODE="devel"
     shift
 fi
 if [ "$1" = "release" ]; then
-    $PRINT_CMD "overriding default execmode $DEFAULT_EXECMODE to: release"
+    $PRINT_WARNING "overriding default execmode $DEFAULT_EXECMODE to: release"
     EXECMODE="release"
     shift
 fi
 
 if [ "$1" = "base" ]; then
-    $PRINT_CMD "overriding default execmode $DEFAULT_EXECMODE to: base"
+    $PRINT_WARNING "overriding default execmode $DEFAULT_EXECMODE to: base"
     EXECMODE="base"
     shift
 fi
 
 # set default argument
 if [ -z "$1" ]; then
-    $PRINT_CMD "No run argument given. Using /bin/bash as default"
+    $PRINT_DEBUG "No run argument given. Using /bin/bash as default"
     set -- "/bin/bash"
 fi
 
@@ -72,9 +72,9 @@ if [ "$EXECMODE" == "release" ]; then
 fi
 
 if [ "$DOCKER_REGISTRY_AUTOPULL" = true ]; then
-    $PRINT_CMD
-    $PRINT_CMD pulling image: $IMAGE_NAME
-    $PRINT_CMD
+    $PRINT_INFO
+    $PRINT_INFO pulling image: $IMAGE_NAME
+    $PRINT_INFO
     docker pull $IMAGE_NAME
 fi
 
@@ -93,9 +93,9 @@ FOLDER_MD5=$(echo $ROOT_DIR | md5sum | cut -b 1-8)
 CONTAINER_NAME=${CONTAINER_NAME:="${ROOT_DIR##*/}-$EXECMODE-$FOLDER_MD5"}
 CONTAINER_ID_FILENAME=$ROOT_DIR/$EXECMODE-container_id.txt
 
-$PRINT_CMD
-$PRINT_CMD -e "\e[32musing ${IMAGE_NAME%:*}:\e[4;33m${IMAGE_NAME#*:}\e[0m"
-$PRINT_CMD
+$PRINT_INFO
+$PRINT_INFO -e "\e[32musing ${IMAGE_NAME%:*}:\e[4;33m${IMAGE_NAME#*:}\e[0m"
+$PRINT_INFO
 
 
 

--- a/image_setup/01_base_images/entrypoint.bash
+++ b/image_setup/01_base_images/entrypoint.bash
@@ -9,7 +9,7 @@
 if [ -z "$PRINT_INFO" ]; then
     # we expect that in info is neither "echo" or ":", nothing has been set
     echo "WARNING: Your docker_image_development scripts are outdated, please update (merge) from https://github.com/dfki-ric/docker_image_development"
-    echo -e "\t* docker_image_developent verbosity levels are disabled, printing everything (as before)"
+    echo -e "\t* docker_image_developent verbosity levels are disabled for ouputs from the image, printing everything (as before)"
     export PRINT_DEBUG=echo
     export PRINT_INFO=echo
     export PRINT_WARNING=echo

--- a/image_setup/01_base_images/entrypoint.bash
+++ b/image_setup/01_base_images/entrypoint.bash
@@ -6,16 +6,15 @@
 
 #set the correct UID from host
 if [ ! -f /initialized_container ]; then
+
+    echo
+    echo -e "\e[33mSetting the containers devel user id to host user id\e[0m"
+    echo
     #only executed by docker run
     sudo touch /initialized_container
     sudo sh /opt/init_user_id.bash
-    #id script needs exit to apply uid nest start
-
-    echo
-    echo -e "\e[33mdevel user id set, logging out automatically\e[0m"
-    echo
-
-    #entrypoit is only executed on docker run, exit here
+    # id script needs exit to apply uid next docker start, so exiting here
+    # the exec script expects this to happen and rund start/exec afterwards
     exit 0
 fi
 

--- a/image_setup/01_base_images/entrypoint.bash
+++ b/image_setup/01_base_images/entrypoint.bash
@@ -4,15 +4,27 @@
 #TODO: set ros_core URI // from outside in run script??
 #get HOST ip /sbin/ip route|awk '/default/ { print $3 }'
 
+
+# in clase of legacy scripts using new base images, set it here
+if [ -z "$PRINT_INFO" ]; then
+    # we expect that in info is neither "echo" or ":", nothing has been set
+    echo "Your docker_image_development scripts are outdated, please update (merge) from https://github.com/dfki-ric/docker_image_development"
+    echo "WARNING: Verbosity levels disabled, printing everything (as before)"
+    export PRINT_DEBUG=echo
+    export PRINT_INFO=echo
+    export PRINT_WARNING=echo
+fi
+
+
 #set the correct UID from host
 if [ ! -f /initialized_container ]; then
 
-    echo
-    echo -e "\e[33mSetting the containers devel user id to host user id\e[0m"
-    echo
+    $PRINT_INFO
+    $PRINT_INFO -e "\e[33mSetting the containers devel user id to host user id\e[0m"
+    $PRINT_INFO
     #only executed by docker run
     sudo touch /initialized_container
-    sudo sh /opt/init_user_id.bash
+    sudo -E /bin/bash /opt/init_user_id.bash
     # id script needs exit to apply uid next docker start, so exiting here
     # the exec script expects this to happen and rund start/exec afterwards
     exit 0

--- a/image_setup/01_base_images/entrypoint.bash
+++ b/image_setup/01_base_images/entrypoint.bash
@@ -8,8 +8,8 @@
 # in clase of legacy scripts using new base images, set it here
 if [ -z "$PRINT_INFO" ]; then
     # we expect that in info is neither "echo" or ":", nothing has been set
-    echo "Your docker_image_development scripts are outdated, please update (merge) from https://github.com/dfki-ric/docker_image_development"
-    echo "WARNING: Verbosity levels disabled, printing everything (as before)"
+    echo "WARNING: Your docker_image_development scripts are outdated, please update (merge) from https://github.com/dfki-ric/docker_image_development"
+    echo -e "\t* docker_image_developent verbosity levels are disabled, printing everything (as before)"
     export PRINT_DEBUG=echo
     export PRINT_INFO=echo
     export PRINT_WARNING=echo
@@ -24,6 +24,7 @@ if [ ! -f /initialized_container ]; then
     $PRINT_INFO
     #only executed by docker run
     sudo touch /initialized_container
+    # use -E to keep env (for PRINT_* environment)
     sudo -E /bin/bash /opt/init_user_id.bash
     # id script needs exit to apply uid next docker start, so exiting here
     # the exec script expects this to happen and rund start/exec afterwards

--- a/image_setup/01_base_images/init_user_id.bash
+++ b/image_setup/01_base_images/init_user_id.bash
@@ -2,13 +2,15 @@
 
 # this script will be called by .bashrc
 
+# $PRINT_DEBUG is set later by the docker run command in docker_commands.bash or by the enrtypoint
+
 # on initialization check if the UID of the rosuser user has to be changed:
 if [ "$NUID" -a ! -f /initialized_uid ]; then
     if [ "$NUID" != "$(id -u devel)" ]; then
-        echo "UID is going to be changed from $(id -u devel) to $NUID"
+        $PRINT_DEBUG "UID is going to be changed from $(id -u devel) to $NUID"
         # if group id is given also:
         if [ "$NGID" ]; then
-            echo "GID is going to be changed from $(id -g devel) to $NGID"
+            $PRINT_DEBUG "GID is going to be changed from $(id -g devel) to $NGID"
             sed s/"x:1000"/"x:$NUID"/ /etc/passwd > /temp
             mv /temp /etc/passwd
             sed s/"1000::"/"$NGID::"/ /etc/passwd > /temp
@@ -21,9 +23,9 @@ if [ "$NUID" -a ! -f /initialized_uid ]; then
         fi
         # change ownerchip to new UID and GID
         chown -R devel:devel-group /home/devel
-        echo -e "\n \033[0;32m EXITING THE CONTAINER PLEASE RELOGIN ! \n(using \"docker start -ai <containername>\")\e[0m"
+        $PRINT_DEBUG -e "\n \033[0;32m EXITING THE CONTAINER PLEASE RELOGIN ! \n(using \"docker start -ai <containername>\")\e[0m"
     else
-        echo "UID did not need to be changed"
+        $PRINT_DEBUG "UID did not need to be changed"
     fi
 fi
 

--- a/image_setup/02_devel_image/Dockerfile
+++ b/image_setup/02_devel_image/Dockerfile
@@ -23,9 +23,10 @@ ADD workspace_os_dependencies.txt /opt/installed_workspace_os_dependencies.txt
 RUN grep -vE '^#' /opt/installed_workspace_os_dependencies.txt | xargs sudo apt install -y
 
 # opt/init_workspace.bash is run once via dockercommands.bash by calling check_init_workspace.bash
-RUN echo "echo" >> /opt/init_workspace.bash
-RUN echo 'echo -e "\e[32mplease run /opt/setup_workspace.bash to initialize the workspace\e[0m"' >> /opt/init_workspace.bash
-RUN echo "echo" >> /opt/init_workspace.bash
+# $PRINT_INFO is set later by the docker run command in docker_commands.bash
+RUN echo '$PRINT_INFO' >> /opt/init_workspace.bash
+RUN echo '$PRINT_INFO -e "\e[32mplease run /opt/setup_workspace.bash to initialize the workspace\e[0m"' >> /opt/init_workspace.bash
+RUN echo '$PRINT_INFO' >> /opt/init_workspace.bash
 
 # If you want to run the setup automatically, you can add it directly to the script
 # it is executed every time the container is re-created

--- a/settings.bash
+++ b/settings.bash
@@ -48,3 +48,7 @@ export WORKSPACE_RELEASE_IMAGE=developmentimage/${PROJECT_NAME}:release
 # --privileged
 # -v /dev/input/:/dev/input
 export ADDITIONAL_DOCKER_RUN_ARGS=""
+
+# Make the exec script to talk more for debugging/docker setup purposes.
+# This may also be stated in the command line: $> VERBOSE=true ./exec.bash 
+# export VERBOSE=true

--- a/settings.bash
+++ b/settings.bash
@@ -52,3 +52,6 @@ export ADDITIONAL_DOCKER_RUN_ARGS=""
 # Make the exec script to talk more for debugging/docker setup purposes.
 # This may also be stated in the command line: $> VERBOSE=true ./exec.bash 
 # export VERBOSE=true
+
+# Make the output as quiet as possible (does not apply to programs started in the container)
+#export SILENT=false


### PR DESCRIPTION
As requested here: https://github.com/dfki-ric/docker_image_development/issues/16

Adds a "VERBOSE=true" setting that suppresses most of the exec scritpt output.

The environment variable "VERBOSE" can be set via settings.bash or directly in the command line:
```bash
VERBOSE=true ./exec.bash
```

