### PR TITLE
add base image versioning

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,3 @@
+1.2.0 - script/base image version handling/comparison
+1.1.0 - better devel image dependency management
 1.0.0 - github release

--- a/docker_commands.bash
+++ b/docker_commands.bash
@@ -5,6 +5,8 @@ ROOT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 DNSIP=$(nmcli dev show | grep 'IP4.DNS' | grep "\[1\]" | egrep -oe "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}" | head -n 1)
 
+SCRIPTSVERSION=$(cat VERSION | head -n1 | awk -F' ' '{print $1}')
+
 PRINT_WARNING=echo
 PRINT_INFO=echo
 PRINT_DEBUG=:
@@ -105,7 +107,7 @@ generate_container(){
 
     #initial run exits no matter what due to entrypoint (user id settings)
     #/bin/bash will be default nonetheless when called later without command
-    docker run -ti $RUNTIME_ARG $DOCKER_RUN_ARGS -e PRINT_WARNING=${PRINT_WARNING} -e PRINT_INFO=${PRINT_INFO} -e PRINT_DEBUG=${PRINT_DEBUG} $IMAGE_NAME || exit 1
+    docker run -ti $RUNTIME_ARG $DOCKER_RUN_ARGS -e SCRIPTSVERSION=${SCRIPTSVERSION} -e PRINT_WARNING=${PRINT_WARNING} -e PRINT_INFO=${PRINT_INFO} -e PRINT_DEBUG=${PRINT_DEBUG} $IMAGE_NAME || exit 1
     # default container exists after initial run
 
     $PRINT_DEBUG "docker start $CONTAINER_NAME"
@@ -128,7 +130,7 @@ generate_container_nonint(){
     $PRINT_DEBUG "generating new non-interactive container with $@"
     echo $CURRENT_IMAGE_ID > $CONTAINER_ID_FILENAME
 
-    docker run -t $RUNTIME_ARG $DOCKER_RUN_ARGS -e PRINT_WARNING=${PRINT_WARNING} -e PRINT_INFO=${PRINT_INFO} -e PRINT_DEBUG=${PRINT_DEBUG} $IMAGE_NAME $@
+    docker run -t $RUNTIME_ARG $DOCKER_RUN_ARGS -e SCRIPTSVERSION=${SCRIPTSVERSION} -e PRINT_WARNING=${PRINT_WARNING} -e PRINT_INFO=${PRINT_INFO} -e PRINT_DEBUG=${PRINT_DEBUG} $IMAGE_NAME $@
     
     # default container exists after initial run
     start_container_nonint $@

--- a/image_setup/01_base_images/Dockerfile
+++ b/image_setup/01_base_images/Dockerfile
@@ -55,6 +55,7 @@ RUN echo "devel ALL=(ALL) NOPASSWD: ALL \
 RUN touch /opt/init_workspace.bash
 ADD check_init_workspace.bash /opt/check_init_workspace.bash 
 
+ADD VERSION /opt/VERSION
 ADD entrypoint.bash /opt/entrypoint.bash
 
 #these scripts must be runnable by users, not only root

--- a/image_setup/01_base_images/build_plain_18.04.bash
+++ b/image_setup/01_base_images/build_plain_18.04.bash
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#copy scripts VERSION file to put it into the image
+cp ../../VERSION ./
+
 . ../../settings.bash
 export IMAGE_NAME=${BASE_REGISTRY:+${BASE_REGISTRY}/}developmentimage/plain_18.04
 
@@ -8,7 +11,6 @@ export INSTALL_SCRIPT=install_plain_dependencies.bash
 
 docker pull $BASE_IMAGE
 docker build --no-cache -f Dockerfile -t $IMAGE_NAME:base --build-arg BASE_IMAGE --build-arg INSTALL_SCRIPT .
-
 
 
 echo

--- a/image_setup/01_base_images/build_plain_20.04.bash
+++ b/image_setup/01_base_images/build_plain_20.04.bash
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#copy scripts VERSION file to put it into the image
+cp ../../VERSION ./
+
 . ../../settings.bash
 export IMAGE_NAME=${BASE_REGISTRY:+${BASE_REGISTRY}/}developmentimage/plain_20.04
 

--- a/image_setup/01_base_images/build_rock_master_16.04.bash
+++ b/image_setup/01_base_images/build_rock_master_16.04.bash
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#copy scripts VERSION file to put it into the image
+cp ../../VERSION ./
+
 . ../../settings.bash
 export IMAGE_NAME=${BASE_REGISTRY:+${BASE_REGISTRY}/}developmentimage/rock_master_16.04
 

--- a/image_setup/01_base_images/build_rock_master_18.04.bash
+++ b/image_setup/01_base_images/build_rock_master_18.04.bash
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#copy scripts VERSION file to put it into the image
+cp ../../VERSION ./
+
 . ../../settings.bash
 export IMAGE_NAME=${BASE_REGISTRY:+${BASE_REGISTRY}/}developmentimage/rock_master_18.04
 

--- a/image_setup/01_base_images/build_rock_master_20.04.bash
+++ b/image_setup/01_base_images/build_rock_master_20.04.bash
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#copy scripts VERSION file to put it into the image
+cp ../../VERSION ./
+
 . ../../settings.bash
 export IMAGE_NAME=${BASE_REGISTRY:+${BASE_REGISTRY}/}developmentimage/rock_master_20.04
 

--- a/image_setup/01_base_images/build_ros_melodic_18.04.bash
+++ b/image_setup/01_base_images/build_ros_melodic_18.04.bash
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#copy scripts VERSION file to put it into the image
+cp ../../VERSION ./
+
 . ../../settings.bash
 export IMAGE_NAME=${BASE_REGISTRY:+${BASE_REGISTRY}/}developmentimage/ros_melodic_18.04
 

--- a/image_setup/01_base_images/build_ros_melodic_18.04_minimal.bash
+++ b/image_setup/01_base_images/build_ros_melodic_18.04_minimal.bash
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#copy scripts VERSION file to put it into the image
+cp ../../VERSION ./
+
 . ../../settings.bash
 export IMAGE_NAME=${BASE_REGISTRY:+${BASE_REGISTRY}/}developmentimage/ros_melodic_18.04_minimal
 

--- a/image_setup/01_base_images/build_ros_noetic_20.04.bash
+++ b/image_setup/01_base_images/build_ros_noetic_20.04.bash
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#copy scripts VERSION file to put it into the image
+cp ../../VERSION ./
+
 . ../../settings.bash
 export IMAGE_NAME=${BASE_REGISTRY:+${BASE_REGISTRY}/}developmentimage/ros_noetic_20.04
 

--- a/image_setup/01_base_images/build_ros_noetic_20.04_minimal.bash
+++ b/image_setup/01_base_images/build_ros_noetic_20.04_minimal.bash
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#copy scripts VERSION file to put it into the image
+cp ../../VERSION ./
+
 . ../../settings.bash
 export IMAGE_NAME=${BASE_REGISTRY:+${BASE_REGISTRY}/}developmentimage/ros_noetic_20.04_minimal
 

--- a/image_setup/01_base_images/entrypoint.bash
+++ b/image_setup/01_base_images/entrypoint.bash
@@ -8,17 +8,77 @@
 # in clase of legacy scripts using new base images, set it here
 if [ -z "$PRINT_INFO" ]; then
     # we expect that in info is neither "echo" or ":", nothing has been set
+    echo
     echo "WARNING: Your docker_image_development scripts are outdated, please update (merge) from https://github.com/dfki-ric/docker_image_development"
     echo -e "\t* docker_image_developent verbosity levels are disabled for ouputs from the image, printing everything (as before)"
+    echo
     export PRINT_DEBUG=echo
     export PRINT_INFO=echo
     export PRINT_WARNING=echo
 fi
 
+IMAGEVERSION=$(cat /opt/VERSION | head -n1 | awk -F' ' '{print $1}')
+#SCRIPTSVERSION provided via ENV in run command
+
+IMAGE_MAJOR=$(echo $IMAGEVERSION | awk -F'.' '{print $1}')
+IMAGE_MINOR=$(echo $IMAGEVERSION | awk -F'.' '{print $2}')
+IMAGE_PATCH=$(echo $IMAGEVERSION | awk -F'.' '{print $3}')
+SCRIPTS_MAJOR=$(echo $SCRIPTSVERSION | awk -F'.' '{print $1}')
+SCRIPTS_MINOR=$(echo $SCRIPTSVERSION | awk -F'.' '{print $2}')
+SCRIPTS_PATCH=$(echo $SCRIPTSVERSION | awk -F'.' '{print $3}')
+
+# if SCRIPTSVERSION is not set at all, the scripts are too old (but compatible)
+if [ -z "$SCRIPTSVERSION" ]; then
+    $PRINT_WARNING
+    $PRINT_WARNING "WARNING: Your docker_image_development scripts are outdated, please update (merge) from https://github.com/dfki-ric/docker_image_development"
+    $PRINT_WARNING -e "\t* docker_image_developent Version checks disabled"
+    $PRINT_WARNING
+else
+    if [ "$IMAGEVERSION" != "$SCRIPTSVERSION" ]; then
+        $PRINT_DEBUG "Scritps/Image version mismatch"
+        # check major versions
+        if [ "$IMAGE_MAJOR" -gt "$SCRIPTS_MAJOR" ]; then
+            echo
+            echo -e "\e[31mError: The image was produced with incompatible scripts\e[0m: Please update your scripts"
+            echo
+            exit 0
+        else
+            if [ "$IMAGE_MINOR" -gt "$SCRIPTS_MINOR" ]; then
+                $PRINT_INFO
+                $PRINT_INFO "The image was produced with a newer minor scripts version: Consider updating your scripts"
+                $PRINT_INFO
+            else
+                if [ "$IMAGE_PATCH" -gt "$SCRIPTS_PATCH" ]; then
+                    $PRINT_DEBUG
+                    $PRINT_DEBUG "The image was produced with a newer patch scripts version: Consider updating your scripts"
+                    $PRINT_DEBUG
+                fi
+            fi
+        fi
+        if [ "$IMAGE_MAJOR" -lt "$SCRIPTS_MAJOR" ]; then
+            echo
+            echo -e "\e[31mError: The image was produced with incompatible scripts version\e[0m: Please update your images"
+            echo
+            exit 0
+        else
+            if [ "$IMAGE_MINOR" -lt "$SCRIPTS_MINOR" ]; then
+                $PRINT_INFO
+                $PRINT_INFO "The image was produced with a lesser minor scripts version: Consider updating your images"
+                $PRINT_INFO
+            else
+                if [ "$IMAGE_PATCH" -lt "$SCRIPTS_PATCH" ]; then
+                    $PRINT_DEBUG
+                    $PRINT_DEBUG "The image was produced with a lesser patch scripts version: Consider updating your images"
+                    $PRINT_DEBUG
+                fi
+            fi
+        fi
+    fi
+fi
+
 
 #set the correct UID from host
 if [ ! -f /initialized_container ]; then
-
     $PRINT_INFO
     $PRINT_INFO -e "\e[33mSetting the containers devel user id to host user id\e[0m"
     $PRINT_INFO


### PR DESCRIPTION
Add versioning (and checks) for base images, as discussed here: https://github.com/dfki-ric/docker_image_development/pull/17

The VERSION file of this repo is copied into the base image, the entrypoint compares the version with the VERSION file of the repo. This way, we can check if the scripts are compatible to the image

We need to start adding tags for the versions and add them to the version file, to be able to get the correct script set for a given image.

This uses semantic versioning: Major version mismatch results in an error, others will run the image but create warnings up update image/scripts.
