### PR TITLE
add release tags to git and devel image

### DIFF
--- a/image_setup/03_release_image/build.bash
+++ b/image_setup/03_release_image/build.bash
@@ -13,6 +13,11 @@ export DEVEL_IMAGE_NAME=${DEVEL_REGISTRY:+${DEVEL_REGISTRY}/}$WORKSPACE_DEVEL_IM
 RELEASE_IMAGE_NAME=${RELEASE_REGISTRY:+${RELEASE_REGISTRY}/}$WORKSPACE_RELEASE_IMAGE
 echo "Buidling release image: ${RELEASE_IMAGE_NAME}_$TAG by $USER on $HOST Date: $DATE"
 
+# tag the docker development repo with the release date
+git tag -a release_$TAG -m"${RELEASE_IMAGE_NAME}_$TAG"
+# tag the devel image used to create the release (for extracting workspaces later)
+docker tag $DEVEL_IMAGE_NAME ${DEVEL_IMAGE_NAME}_$TAG
+
 docker build --no-cache --build-arg DEVEL_IMAGE_NAME --build-arg USER --build-arg HOST --build-arg DATE -f Dockerfile -t $RELEASE_IMAGE_NAME ../..
 
 echo "tagging $RELEASE_IMAGE_NAME as ${RELEASE_IMAGE_NAME}_$TAG"
@@ -22,4 +27,5 @@ echo
 echo "don't forget to push the image if you wish:"
 echo "docker push $RELEASE_IMAGE_NAME"
 echo "docker push ${RELEASE_IMAGE_NAME}_$TAG"
+echo "docker push ${DEVEL_IMAGE_NAME}_$TAG"
 echo


### PR DESCRIPTION
Add More tagging for release images:

* tag docker_image_development repo with the release name to be able to restore the scripts compatible with the release
* tag the devel image that was used to create the release to keep a compatible devel image for workspace extraction