### PR TITLE
Use ROOT_DIR through docker_command script, change write_osdeps arg

### DIFF
--- a/autocomplete.me
+++ b/autocomplete.me
@@ -2,6 +2,9 @@
 
 ROOT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 export PATH=$ROOT_DIR${PATH:+:${PATH}}
-complete -W "base devel release $(ls startscripts | xargs) /bin/bash /opt/write_osdeps.bash" ./exec.bash
+complete -W "base devel release $(ls startscripts | xargs) /bin/bash write_osdeps" ./exec.bash
 complete -W "base devel release" ./stop.bash
 complete -W "base devel release" ./delete_container.bash
+complete -W "base devel release $(ls startscripts | xargs) /bin/bash write_osdeps" exec.bash
+complete -W "base devel release" stop.bash
+complete -W "base devel release" delete_container.bash

--- a/docker_commands.bash
+++ b/docker_commands.bash
@@ -3,7 +3,7 @@
 ROOT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . $ROOT_DIR/settings.bash
 
-SCRIPTSVERSION=$(cat VERSION | head -n1 | awk -F' ' '{print $1}')
+SCRIPTSVERSION=$(cat $ROOT_DIR/VERSION | head -n1 | awk -F' ' '{print $1}')
 
 PRINT_WARNING=echo
 PRINT_INFO=echo
@@ -29,8 +29,8 @@ fi
 
 check_config_file_exists(){
     #init config file, if nonexistent
-    if [ ! -f .container_config.txt ]; then
-        echo "# do not edit, this file is generated and updated automatically when running exec.bash" >> .container_config.txt
+    if [ ! -f $ROOT_DIR/.container_config.txt ]; then
+        echo "# do not edit, this file is generated and updated automatically when running exec.bash" >> $ROOT_DIR/.container_config.txt
     fi
 }
 
@@ -39,14 +39,14 @@ write_value_to_config_file(){
     check_config_file_exists
     # to be able to write, the value must already exits in the file
     # find old var line
-    OLDLINE=$(cat .container_config.txt | grep $1)
+    OLDLINE=$(cat $ROOT_DIR/.container_config.txt | grep $1)
     NEWLINE="$1=$2"
     if [ "$OLDLINE" = "" ]; then 
         # new value, just append
-        echo "$NEWLINE" >> .container_config.txt
+        echo "$NEWLINE" >> $ROOT_DIR/.container_config.txt
     else
         #value exists, replace line
-        sed -i "s/$OLDLINE/$NEWLINE/g" .container_config.txt
+        sed -i "s/$OLDLINE/$NEWLINE/g" $ROOT_DIR/.container_config.txt
     fi
 }
 
@@ -54,7 +54,7 @@ read_value_from_config_file(){
     #check if file exists and create if nonexistent
     check_config_file_exists
     READVARNAME=$1
-    echo $(cat .container_config.txt | grep $READVARNAME | awk -F'=' '{print $2}')
+    echo $(cat $ROOT_DIR/.container_config.txt | grep $READVARNAME | awk -F'=' '{print $2}')
 }
 
 

--- a/exec.bash
+++ b/exec.bash
@@ -7,6 +7,7 @@ ROOT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source $ROOT_DIR/docker_commands.bash
 
 CONTAINER_USER=devel
+CMD_STRING=""
 
 ### EVALUATE ARGUMENTS AND SET EXECMODE
 EXECMODE=$DEFAULT_EXECMODE
@@ -26,10 +27,15 @@ if [ "$1" = "release" ]; then
     shift
 fi
 
-# set default argument
+# evaluate arguments or set default argument
 if [ -z "$1" ]; then
-    $PRINT_DEBUG "No run argument given. Using /bin/bash as default"
+    CMD_STRING="No run argument given. Executing: /bin/bash"
     set -- "/bin/bash"
+elif [ "$1" == "write_osdeps" ]; then
+    CMD_STRING="Executing: /opt/write_osdeps.bash"
+    set -- "/opt/write_osdeps.bash"
+else 
+    CMD_STRING="Executing: $1"
 fi
 
 ### START EXECUTION
@@ -102,6 +108,8 @@ CONTAINER_NAME=${CONTAINER_NAME:="${ROOT_DIR##*/}-$EXECMODE-$FOLDER_MD5"}
 $PRINT_INFO
 $PRINT_INFO -e "\e[32musing ${IMAGE_NAME%:*}:\e[4;33m${IMAGE_NAME##*:}\e[0m"
 $PRINT_INFO
+$PRINT_DEBUG $CMD_STRING
+$PRINT_DEBUG
 
 CONTAINER_IMAGE_ID=$(read_value_from_config_file $EXECMODE)
 CURRENT_IMAGE_ID=$(docker inspect --format '{{.Id}}' $IMAGE_NAME)


### PR DESCRIPTION
For one this is a reminder to us to continually prefix host files with $ROOT_DIR to respect that we now have the option to exec.bash from anywhere in the repo. To support that feature I added exec.bash, stop.bash and delete_container.bash without ./ prefix to the autocomplete file.

Furthermore I got rid of the `/opt/write_osdeps.bash` argument. Well not really getting rid of it, but I changed it to `write_osdeps`. That seemed more intuitive and does not compete with `/bin/bash` regarding tab completion. The argument is resolved in exec.bash and prepares a if/elif struct for future arguments.

Managing the output of this argument evaluation I introduced a CMD_STRING variable to the exec file. It is just debug output, but I found the first line of console output is quickly overlooked as the colored `using blabla image` line takes away all the attention. Which I think is good in principle as it is important information, but I thought from a logical sequential perspective the `Executing: <command>` output makes more sense afterwards anyway.