### PR TITLE
Fix execution mode evaluation in exec. Adapt test_suite to dockeruser

### DIFF
--- a/exec.bash
+++ b/exec.bash
@@ -12,7 +12,7 @@ CMD_STRING=""
 
 ### EVALUATE ARGUMENTS AND SET EXECMODE
 EXECMODE=$1
-if [[ ${EXECMODES[*]} =~ $EXECMODE ]]; then
+if [[ " ${EXECMODES[*]} " =~ " $EXECMODE " ]]; then
     $PRINT_WARNING "overriding default execmode $DEFAULT_EXECMODE to: $EXECMODE"
     shift
 else

--- a/image_setup/03_release_image/store.bash
+++ b/image_setup/03_release_image/store.bash
@@ -12,6 +12,14 @@ source $ROOT_DIR/.docker_scripts/variables.bash
 
 STORED_IMAGE_NAME=$2
 RELEASE_IMAGE_NAME=$1
+
+if [[ " ${EXECMODES[*]} " =~ " ${RELEASE_IMAGE_NAME##*:} " ]]; then
+    $PRINT_WARNING "Trying to store image with plain <${RELEASE_IMAGE_NAME##*:}> tag."
+    $PRINT_WARNING "This tag is not unique and might cause the stored image to be overwritten!"
+    $PRINT_WARNING "Please use a unique name, e.g. the date tagged release image, or manually tag the image before storing."
+    exit
+fi
+
 STORED_IMAGES_FILE=$ROOT_DIR/.stored_images.txt
 
 # create image list, if not available

--- a/tools/test_suite/bats/exec_stop_delete_container.bats
+++ b/tools/test_suite/bats/exec_stop_delete_container.bats
@@ -7,25 +7,18 @@ load test_helper
   run bash $ROOT_DIR/exec.bash $EXECMODE whoami
 
   if [ "$EXECMODE" == "base" ]; then
-    user="devel"
     IMAGE=$WORKSPACE_BASE_IMAGE
   elif [ "$EXECMODE" == "devel" ]; then
-    user="devel"
     IMAGE=$WORKSPACE_DEVEL_IMAGE
   elif [ "$EXECMODE" == "release" ]; then
-    user="release"
     IMAGE=$WORKSPACE_RELEASE_IMAGE
-  elif [ "$EXECMODE" == "storedrelease" ]; then
-    user="release"
-  elif [ "$EXECMODE" == "CD" ]; then
-    user="release"
   else
     echo "# [ERROR] unknown execution mode: $EXECMODE" >&3
     exit 1
   fi
 
   [ "$status" -eq 0 ]
-  [ "$(echo ${lines[-1]} | tr -d '\r')" == "$user" ]
+  [ "$(echo ${lines[-1]} | tr -d '\r')" == "dockeruser" ]
   docker container ls | grep --silent $CONTAINER_NAME
   [ "$?" -eq 0 ]
   docker container ls | grep "$CONTAINER_NAME" | grep --silent "$IMAGE"

--- a/tools/test_suite/test_suite.bash
+++ b/tools/test_suite/test_suite.bash
@@ -11,10 +11,10 @@ check_container_existance(){
     CONTAINER_NAME="${ROOT_DIR##*/}-$EXECMODE-$FOLDER_MD5"
     docker container ls -a | grep --silent $CONTAINER_NAME && return=$? || return=$?
     if [ "$return" -eq 0 ]; then
-        echo "[ERROR] The container $CONTAINER_NAME exists and might still be running."
-        echo "        In order to run the test suite, the container needs to be stopped and deleted."
+        echo "[WARN] The container $CONTAINER_NAME exists and might still be running."
+        echo "       In order to run the test suite, the container needs to be stopped and deleted."
         echo
-        read -p "     => stop and delete $CONTAINER_NAME? (Y/N): " confirm
+        read -p "    => stop and delete $CONTAINER_NAME? (Y/N): " confirm
         if [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]]; then
             echo
             bash $ROOT_DIR/delete_container.bash $EXECMODE


### PR DESCRIPTION
I just ran the new exec.bash script and the array evaluation was flawed. Please merge as exec.bash is currently broken on master!