### PR TITLE
fix setting access rights for the ccache dir

### DIFF
--- a/image_setup/01_base_images/entrypoint.bash
+++ b/image_setup/01_base_images/entrypoint.bash
@@ -88,7 +88,8 @@ if [ ! -f /initialized_container ]; then
     # create ccache dir, if variable set (enabled in settings and CCACHE_DIR set in run command)
     if [ ! "$CCACHE_DIR" = "" ]; then
         sudo mkdir -p $CCACHE_DIR
-        sudo chown dockeruser $CCACHE_DIR
+        # the develuser might still have the wrong id, so using the NUID here
+        sudo chown $NUID $CCACHE_DIR
     fi
 
     # use -E to keep env (for PRINT_* environment)


### PR DESCRIPTION
At this point on docker run the develuser is set to default (called before set_user_id), also set_user_id is only effective after running bash again.
So set the permissions based on the NUID end var (the desired uid of develuser after restart)