### PR TITLE
Autodetect xserver type and run paramater changes

### DIFF
--- a/.docker_scripts/docker_commands.bash
+++ b/.docker_scripts/docker_commands.bash
@@ -7,9 +7,9 @@ source $ROOT_DIR/.docker_scripts/file_handling.bash
 
 check_run_args_changed(){
     CURRENT_RUN_ARGS=$(echo $DOCKER_RUN_ARGS $DOCKER_XSERVER_ARGS | md5sum | cut -b 1-32)
-    OLD_RUN_ARGS=$(read_value_from_config_file RUN_ARGS)
+    OLD_RUN_ARGS=$(read_value_from_config_file ${EXECMODE}_RUN_ARGS)
     if [ "$OLD_RUN_ARGS" != "$CURRENT_RUN_ARGS" ]; then
-        write_value_to_config_file RUN_ARGS "$CURRENT_RUN_ARGS"
+        write_value_to_config_file "${EXECMODE}_RUN_ARGS" "$CURRENT_RUN_ARGS"
         RUN_ARGS_CHANGED=true
     else
         RUN_ARGS_CHANGED=false

--- a/.docker_scripts/docker_commands.bash
+++ b/.docker_scripts/docker_commands.bash
@@ -7,9 +7,9 @@ source $ROOT_DIR/.docker_scripts/file_handling.bash
 
 check_run_args_changed(){
     CURRENT_RUN_ARGS=$(echo $DOCKER_RUN_ARGS $DOCKER_XSERVER_ARGS | md5sum | cut -b 1-32)
-    OLD_RUN_ARGS=$(read_value_from_config_file ${EXECMODE}_RUN_ARGS)
+    OLD_RUN_ARGS=$(read_value_from_config_file RUN_ARGS_${EXECMODE})
     if [ "$OLD_RUN_ARGS" != "$CURRENT_RUN_ARGS" ]; then
-        write_value_to_config_file "${EXECMODE}_RUN_ARGS" "$CURRENT_RUN_ARGS"
+        write_value_to_config_file "RUN_ARGS_${EXECMODE}" "$CURRENT_RUN_ARGS"
         RUN_ARGS_CHANGED=true
     else
         RUN_ARGS_CHANGED=false

--- a/.docker_scripts/docker_commands.bash
+++ b/.docker_scripts/docker_commands.bash
@@ -5,6 +5,17 @@ source $ROOT_DIR/settings.bash
 source $ROOT_DIR/.docker_scripts/variables.bash
 source $ROOT_DIR/.docker_scripts/file_handling.bash
 
+check_run_args_changed(){
+    CURRENT_RUN_ARGS=$(echo $DOCKER_RUN_ARGS $DOCKER_XSERVER_ARGS | md5sum | cut -b 1-32)
+    OLD_RUN_ARGS=$(read_value_from_config_file RUN_ARGS)
+    if [ "$OLD_RUN_ARGS" != "$CURRENT_RUN_ARGS" ]; then
+        write_value_to_config_file RUN_ARGS "$CURRENT_RUN_ARGS"
+        RUN_ARGS_CHANGED=true
+    else
+        RUN_ARGS_CHANGED=false
+    fi
+}
+
 init_docker(){
     #detect if nvidia runtime is available
     RUNTIMES=$(docker info | grep "Runtimes:")
@@ -42,11 +53,12 @@ init_docker(){
         #check if the local image is newer that the one the container was created with
         #generate_container saves the current id to a file
         $PRINT_DEBUG "found existing container"
-        if [ "$CURRENT_IMAGE_ID" = "$CONTAINER_IMAGE_ID" ]; then
+        check_run_args_changed
+        if [ "$RUN_ARGS_CHANGED" = "false" ] && [ "$CURRENT_IMAGE_ID" = "$CONTAINER_IMAGE_ID" ]; then
             $PRINT_DEBUG "using existing container"
             start_container $@
         else
-            $PRINT_INFO "Image id is newer than container image id, removing old container: $CONTAINER_NAME"
+            $PRINT_INFO "Image or run arguments changed, renewing container: $CONTAINER_NAME"
             #stop the container in case it is running
             docker stop $CONTAINER_NAME  > /dev/null
             docker rm $CONTAINER_NAME  > /dev/null

--- a/.docker_scripts/docker_commands.bash
+++ b/.docker_scripts/docker_commands.bash
@@ -78,8 +78,9 @@ check_iceccd(){
 
 check_xpra(){
     if [ "$DOCKER_XSERVER_TYPE" = "xpra" ]; then
-        $PRINT_INFO "starting xpra with DISPLAY=:10000 and ARGS: --sharing=yes --bind-tcp=0.0.0.0:$XPRA_PORT"
-        docker exec $CONTAINER_NAME /bin/bash -c 'xpra start $DISPLAY --sharing=yes --bind-tcp=0.0.0.0:$XPRA_PORT &> /dev/null'
+        $PRINT_INFO "using xpra server: xpra start :$XPRA_PORT --sharing=yes --bind-tcp=0.0.0.0:$XPRA_PORT"
+        $PRINT_INFO -e "\nRemember to start the xpra client on your PC:\n\txpra attach tcp:<THIS_PC_IP>:$XPRA_PORT\n\txpra attach tcp:127.0.0.1:$XPRA_PORT\n"
+        docker exec $CONTAINER_NAME /bin/bash -c 'xpra start $DISPLAY --sharing=yes --bind-tcp=0.0.0.0:$XPRA_PORT 2> /dev/null && echo'
     fi
 }
 

--- a/.docker_scripts/exec.bash
+++ b/.docker_scripts/exec.bash
@@ -130,8 +130,22 @@ DOCKER_RUN_ARGS=" \
                 "
 
 DOCKER_XSERVER_ARGS=""
+if [ -n "$SSH_CLIENT" ] || [ -n "$SSH_TTY" ]; then
+  IS_SSH_TERMINAL=true
+fi
+
+if [ "$DOCKER_XSERVER_TYPE" = "auto" ]; then
+    if [ -n "$IS_SSH_TERMINAL" ]; then
+        $PRINT_INFO "exec.bash was executed in ssh terminal, using xpra for X Apps"
+        DOCKER_XSERVER_TYPE=xpra
+    else
+        $PRINT_INFO "exec.bash was executed in local terminal, using mount for X Apps"
+        DOCKER_XSERVER_TYPE=mount
+    fi
+fi
+
 if [ "$DOCKER_XSERVER_TYPE" = "mount" ]; then
-    DOCKER_XSERVER_ARGS="-e DISPLAY -e QT_X11_NO_MITSHM=1 -v /tmp/.X11-unix:/tmp/.X11-unix -v $HOME/.Xauthority:/home/dockeruser/.Xauthority"
+    DOCKER_XSERVER_ARGS="-e DISPLAY -e QT_X11_NO_MITSHM=1 -v /tmp/.X11-unix:/tmp/.X11-unix -v $HOME/.Xauthority/:/home/dockeruser/.Xauthority/:rw"
 fi
 
 if [ "$DOCKER_XSERVER_TYPE" = "xpra" ]; then

--- a/settings.bash
+++ b/settings.bash
@@ -74,8 +74,9 @@ export ADDITIONAL_DOCKER_RUN_ARGS=""
 # You'll have to enable the use of icecc for your workspace manually, this only set up the availability of icecc in the container
 # export USE_ICECC=true
 
-# conenct to xverver via [mount, xpra, none]
-export DOCKER_XSERVER_TYPE=mount
+# conenct to xserver via [mount, xpra, none, auto]
+# auto will detect if the container is started over an ssh session and if yes, xpra is used, mount otherwise
+export DOCKER_XSERVER_TYPE=auto
 #xpra_port may be set if --net=host is used, otherwise, please use -p in the ADDITIONAL_DOCKER_RUN_ARGS to assign a port for the
 #xpra server, DOCKER_XSERVER_TYPE needs to be "xpra"
 export XPRA_PORT="10000"


### PR DESCRIPTION
* xserver type setting now has an auto setting, if set and ./exec.bash is run through ssh, "xpra" is used, if exec.bash is run locally, the "mount" xserver type is used
* changes in the run arguments are detected and the container is rebuild if there were changes