### PR TITLE
test for empty var and move to own function

### DIFF
--- a/.docker_scripts/docker_commands.bash
+++ b/.docker_scripts/docker_commands.bash
@@ -94,7 +94,7 @@ check_iceccd(){
 check_xpra(){
     if [ "$DOCKER_XSERVER_TYPE" = "xpra" ]; then
         $PRINT_INFO "using xpra server: xpra start :$XPRA_PORT --sharing=yes --bind-tcp=0.0.0.0:$XPRA_PORT"
-        $PRINT_INFO -e "\nRemember to start the xpra client on your PC:\n\txpra attach tcp:<THIS_PC_IP>:$XPRA_PORT\n\txpra attach tcp:127.0.0.1:$XPRA_PORT\n"
+        $PRINT_INFO -e "\nRemember to start the xpra client on your PC:\n    bash xpra_attach.bash"
         docker exec $CONTAINER_NAME /bin/bash -c 'xpra start $DISPLAY --sharing=yes --bind-tcp=0.0.0.0:$XPRA_PORT 2> /dev/null && echo'
     fi
 }

--- a/.docker_scripts/exec.bash
+++ b/.docker_scripts/exec.bash
@@ -112,25 +112,5 @@ DOCKER_RUN_ARGS=" \
                 $ADDITIONAL_DOCKER_MOUNT_ARGS \
                 "
 
-DOCKER_XSERVER_ARGS=""
-if [ -n "$SSH_CLIENT" ] || [ -n "$SSH_TTY" ]; then
-  IS_SSH_TERMINAL=true
-fi
-
-if [ "$DOCKER_XSERVER_TYPE" = "auto" ]; then
-    if [ -n "$IS_SSH_TERMINAL" ]; then
-        $PRINT_INFO "exec.bash was executed in ssh terminal, using xpra for X Apps"
-        DOCKER_XSERVER_TYPE=xpra
-    else
-        $PRINT_INFO "exec.bash was executed in local terminal, using mount for X Apps"
-        DOCKER_XSERVER_TYPE=mount
-    fi
-fi
-
-if [ "$DOCKER_XSERVER_TYPE" = "mount" ]; then
-    DOCKER_XSERVER_ARGS="-e DISPLAY -e QT_X11_NO_MITSHM=1 -v /tmp/.X11-unix:/tmp/.X11-unix"
-fi
-
-if [ "$DOCKER_XSERVER_TYPE" = "xpra" ]; then
-    DOCKER_XSERVER_ARGS="-e USE_XPRA=true -e DISPLAY=:10000 -e XPRA_PORT"
-fi
+# check which xserver type should be used and set additional args accordingly
+set_xserver_args

--- a/exec.bash
+++ b/exec.bash
@@ -7,7 +7,6 @@ fi
 
 ROOT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source $ROOT_DIR/.docker_scripts/docker_commands.bash
-source $ROOT_DIR/.docker_scripts/variables.bash
 source $ROOT_DIR/.docker_scripts/exec.bash
 
 init_docker $@

--- a/xpra_attach.bash
+++ b/xpra_attach.bash
@@ -3,4 +3,8 @@
 ROOT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source $ROOT_DIR/.docker_scripts/variables.bash
 
+command -v xpra > /dev/null 2>&1
+if [ "$?" -ne "0" ]; then
+    echo -e "Please install xpra:\n    sudo apt install xpra" && exit 13
+fi
 xpra attach --sharing=yes tcp:127.0.0.1:$XPRA_PORT


### PR DESCRIPTION
Had the issue in a downstream repo that the settings.bash was not properly updated and due to unset `DOCKER_XSERVER_TYPE` the `DISPLAY` variable was unset.

Added a check for that and moved everything to its own function in docker_scripts.

Also removed recursive script sourcing in `exec.bash`