### PR TITLE
fix registry overrides

### DIFF
--- a/.docker_scripts/docker_commands.bash
+++ b/.docker_scripts/docker_commands.bash
@@ -94,7 +94,7 @@ check_iceccd(){
 check_xpra(){
     if [ "$DOCKER_XSERVER_TYPE" = "xpra" ]; then
         $PRINT_INFO "using xpra server: xpra start :$XPRA_PORT --sharing=yes --bind-tcp=0.0.0.0:$XPRA_PORT"
-        $PRINT_INFO -e "\nRemember to start the xpra client on your PC:\n\txpra attach tcp:<THIS_PC_IP>:$XPRA_PORT\n\txpra attach tcp:127.0.0.1:$XPRA_PORT\n"
+        $PRINT_INFO -e "\nRemember to start the xpra client on your PC:\n    bash xpra_attach.bash"
         docker exec $CONTAINER_NAME /bin/bash -c 'xpra start $DISPLAY --sharing=yes --bind-tcp=0.0.0.0:$XPRA_PORT 2> /dev/null && echo'
     fi
 }

--- a/.docker_scripts/exec.bash
+++ b/.docker_scripts/exec.bash
@@ -112,25 +112,5 @@ DOCKER_RUN_ARGS=" \
                 $ADDITIONAL_DOCKER_MOUNT_ARGS \
                 "
 
-DOCKER_XSERVER_ARGS=""
-if [ -n "$SSH_CLIENT" ] || [ -n "$SSH_TTY" ]; then
-  IS_SSH_TERMINAL=true
-fi
-
-if [ "$DOCKER_XSERVER_TYPE" = "auto" ]; then
-    if [ -n "$IS_SSH_TERMINAL" ]; then
-        $PRINT_INFO "exec.bash was executed in ssh terminal, using xpra for X Apps"
-        DOCKER_XSERVER_TYPE=xpra
-    else
-        $PRINT_INFO "exec.bash was executed in local terminal, using mount for X Apps"
-        DOCKER_XSERVER_TYPE=mount
-    fi
-fi
-
-if [ "$DOCKER_XSERVER_TYPE" = "mount" ]; then
-    DOCKER_XSERVER_ARGS="-e DISPLAY -e QT_X11_NO_MITSHM=1 -v /tmp/.X11-unix:/tmp/.X11-unix"
-fi
-
-if [ "$DOCKER_XSERVER_TYPE" = "xpra" ]; then
-    DOCKER_XSERVER_ARGS="-e USE_XPRA=true -e DISPLAY=:10000 -e XPRA_PORT"
-fi
+# check which xserver type should be used and set additional args accordingly
+set_xserver_args

--- a/.docker_scripts/variables.bash
+++ b/.docker_scripts/variables.bash
@@ -34,23 +34,6 @@ if [ "$SILENT" = true ]; then
     PRINT_DEBUG=:
 fi
 
-
-# In case you are using CD server and need to use other registries, they can be overridden via env variables
-if [ ! "$OVERRIDE_BASE_REGISTRY" = "" ]; then
-    export OLD_BASE_REGISTRY=$BASE_REGISTRY
-    export BASE_REGISTRY=$OVERRIDE_BASE_REGISTRY
-fi
-
-if [ ! "$OVERRIDE_DEVEL_REGISTRY" = "" ]; then
-    export OLD_DEVEL_REGISTRY=$DEVEL_REGISTRY
-    export DEVEL_REGISTRY=$OVERRIDE_DEVEL_REGISTRY
-fi
-
-if [ ! "$OVERRIDE_RELEASE_REGISTRY" = "" ]; then
-    export OLD_RELEASE_REGISTRY=$RELEASE_REGISTRY
-    export RELEASE_REGISTRY=$OVERRIDE_RELEASE_REGISTRY
-fi
-
 function evaluate_execmode(){
     EXECMODE=$1
     if [ "$EXECMODE" = "" ]; then
@@ -58,9 +41,30 @@ function evaluate_execmode(){
     fi
 }
 
+function check_registry_overrides() {
+    # In case you are using CD server and need to use other registries, they can be overridden via env variables
+    if [ ! "$OVERRIDE_BASE_REGISTRY" = "" ]; then
+        export OLD_BASE_REGISTRY=$BASE_REGISTRY
+        export BASE_REGISTRY=$OVERRIDE_BASE_REGISTRY
+        $PRINT_DEBUG "Overriding devel registry from $OLD_BASE_REGISTRY to $BASE_REGISTRY"
+    fi
+    
+    if [ ! "$OVERRIDE_DEVEL_REGISTRY" = "" ]; then
+        export OLD_DEVEL_REGISTRY=$DEVEL_REGISTRY
+        export DEVEL_REGISTRY=$OVERRIDE_DEVEL_REGISTRY
+        $PRINT_DEBUG "Overriding devel registry from $OLD_DEVEL_REGISTRY to $DEVEL_REGISTRY"
+    fi
+    
+    if [ ! "$OVERRIDE_RELEASE_REGISTRY" = "" ]; then
+        export OLD_RELEASE_REGISTRY=$RELEASE_REGISTRY
+        export RELEASE_REGISTRY=$OVERRIDE_RELEASE_REGISTRY
+        $PRINT_DEBUG "Overriding devel registry from $OLD_RELEASE_REGISTRY to $RELEASE_REGISTRY"
+    fi
+}
 
 # DOCKER_REGISTRY and WORKSPACE_${EXECMODE}_IMAGE from settings.bash
 function set_image_name(){
+    check_registry_overrides
     if [ "$EXECMODE" = "base" ]; then
         IMAGE_NAME=${BASE_REGISTRY:+${BASE_REGISTRY}/}$WORKSPACE_BASE_IMAGE
     fi

--- a/exec.bash
+++ b/exec.bash
@@ -7,7 +7,6 @@ fi
 
 ROOT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source $ROOT_DIR/.docker_scripts/docker_commands.bash
-source $ROOT_DIR/.docker_scripts/variables.bash
 source $ROOT_DIR/.docker_scripts/exec.bash
 
 init_docker $@

--- a/xpra_attach.bash
+++ b/xpra_attach.bash
@@ -3,4 +3,8 @@
 ROOT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source $ROOT_DIR/.docker_scripts/variables.bash
 
+command -v xpra > /dev/null 2>&1
+if [ "$?" -ne "0" ]; then
+    echo -e "Please install xpra:\n    sudo apt install xpra" && exit 13
+fi
 xpra attach --sharing=yes tcp:127.0.0.1:$XPRA_PORT


### PR DESCRIPTION
I realized through buildserver issues that removing the seamingly redundant include/source of variables.bash broke the registry override. Therefore I moved the override check into the `set_image_name` function. As far as I see this is the only relevant location were the image name is set.

Also added some debug prints for the overrides