### PR TITLE
Add pre_exec_hooks

### DIFF
--- a/.docker_scripts/docker_commands.bash
+++ b/.docker_scripts/docker_commands.bash
@@ -8,6 +8,16 @@ source $ROOT_DIR/.docker_scripts/file_handling.bash
 #storage variable for the return value of the docker exec command
 DOCKER_EXEC_RETURN_VALUE=1
 
+run_pre_exec_hooks(){
+    PRE_EXEC_HOOKS_DIR="$ROOT_DIR/image_setup/02_devel_image/pre_exec_hooks"
+    if [ -d $PRE_EXEC_HOOKS_DIR ]; then
+      for script in $(find $PRE_EXEC_HOOKS_DIR -regextype sed -regex "^.*/[0-9]\{2\}[-a-zA-Z0-9._]*.bash$" | sort); do
+        $PRINT_WARNING "Executing: $(basename $script) in $PRE_EXEC_HOOKS_DIR"
+        bash $script
+      done     
+    fi
+}
+
 check_run_args_changed(){
     CURRENT_RUN_ARGS=$(echo $DOCKER_RUN_ARGS $DOCKER_XSERVER_ARGS | md5sum | cut -b 1-32)
     OLD_RUN_ARGS=$(read_value_from_config_file RUN_ARGS_${EXECMODE})

--- a/.docker_scripts/exec.bash
+++ b/.docker_scripts/exec.bash
@@ -2,6 +2,9 @@
 
 CMD_STRING=""
 
+### RUNNING SCRIPTS LOCATED IN image_setup/02_devel_image/pre_exec_hooks ON HOST
+run_pre_exec_hooks
+
 ### EVALUATE ARGUMENTS AND SET EXECMODE
 EXECMODE=$1
 if [[ " ${EXECMODES[*]} " =~ " $EXECMODE " ]]; then

--- a/image_setup/02_devel_image/pre_exec_hooks/readme.md
+++ b/image_setup/02_devel_image/pre_exec_hooks/readme.md
@@ -1,0 +1,4 @@
+### INFO
+In order to execute scripts on the host before generating or starting a container, for instance for creating udev rules, you may place bash scripts in this folder
+The scripts need a double digit numbered prefix and a .bash file ending (e.g. 01_hello_world.bash)
+Scripts will be executed in order!


### PR DESCRIPTION
Functionality wise this works well. However I am unsure where to place this. I feel in the .docker_scripts directory it is too hidden. In the root directory it is to top level for its functionality. In the 02_devel_image directory it seems okay, but would need some further work to properly integrate/copy/apply it to the release images.

Maybe it could be time for a top level config directory?