### PR TITLE
Add base image for ros2 humble on 22.04

### DIFF
--- a/image_setup/01_base_images/build_ros2_humble_22.04.bash
+++ b/image_setup/01_base_images/build_ros2_humble_22.04.bash
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+#copy scripts VERSION file to put it into the image
+cp ../../VERSION ./
+
+. ../../settings.bash
+export IMAGE_NAME=${BASE_REGISTRY:+${BASE_REGISTRY}/}developmentimage/ros2_humble_22.04
+
+export BASE_IMAGE=developmentimage/plain_22.04_nogl:base
+export INSTALL_SCRIPT=install_ros2_dependencies.bash
+export INSTALL_ARGS=humble
+
+docker pull $BASE_IMAGE
+docker build --no-cache -f Dockerfile -t $IMAGE_NAME:base --build-arg BASE_IMAGE --build-arg INSTALL_SCRIPT --build-arg INSTALL_ARGS --label "base-image-name=$IMAGE_NAME:base" --label "base-image-created-from=${BASE_IMAGE} - $(docker inspect --format '{{.Id}}' $BASE_IMAGE)" --label "dockerfile_repo_commit=$(git rev-parse HEAD)" .
+
+# remove VERSION file from here
+rm -rf VERSION
+
+echo
+echo "don't forget to push the image if you wish:"
+echo "docker push $IMAGE_NAME:base"
+echo
+

--- a/image_setup/01_base_images/build_ros2_humble_22.04_nogl.bash
+++ b/image_setup/01_base_images/build_ros2_humble_22.04_nogl.bash
@@ -5,9 +5,9 @@ set -e
 cp ../../VERSION ./
 
 . ../../settings.bash
-export IMAGE_NAME=${BASE_REGISTRY:+${BASE_REGISTRY}/}developmentimage/ros2_humble_22.04
+export IMAGE_NAME=${BASE_REGISTRY:+${BASE_REGISTRY}/}developmentimage/ros2_humble_22.04_nogl
 
-export BASE_IMAGE=developmentimage/plain_22.04_nogl:base
+export BASE_IMAGE=ubuntu:22.04
 export INSTALL_SCRIPT=install_ros2_dependencies.bash
 export INSTALL_ARGS=humble
 

--- a/image_setup/01_base_images/install_ros2_dependencies.bash
+++ b/image_setup/01_base_images/install_ros2_dependencies.bash
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-#install ROS2 Foxy 
+#install ROS2
 export DEBIAN_FRONTEND=noninteractive
 export vPYTHON=3
-export DISTRO="foxy"
+export DISTRO=${1:-foxy}
 
 apt update && apt install -y \
     lsb-release \
@@ -13,16 +13,15 @@ apt update && apt install -y \
     locales \
     software-properties-common
 
-
 locale-gen en_US en_US.UTF-8
 update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 export LANG=en_US.UTF-8
 
-sudo add-apt-repository universe
+add-apt-repository universe
 
-sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
+curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
 
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
 
 apt update && apt upgrade -y &&  apt install -y \
     ros-$DISTRO-desktop \

--- a/settings.bash
+++ b/settings.bash
@@ -32,7 +32,7 @@ export DEFAULT_EXECMODE="base" # Use this only for setting up the initial devel 
 export WORKSPACE_BASE_IMAGE=developmentimage/plain_20.04:base # plain image with build_essentials installed
 # export WORKSPACE_BASE_IMAGE=developmentimage/plain_22.04_nogl:base # plain image with build_essentials installed
 # export WORKSPACE_BASE_IMAGE=developmentimage/ros2_foxy_20.04:base # image with ros2 foxy desktop installed
-
+# export WORKSPACE_BASE_IMAGE=developmentimage/ros2_humble_22.04:base # image with ros2 humble desktop installed
 
 # The Name of the Workspace image to use
 # you should add a workspace name folder and a image name

--- a/settings.bash
+++ b/settings.bash
@@ -32,7 +32,7 @@ export DEFAULT_EXECMODE="base" # Use this only for setting up the initial devel 
 export WORKSPACE_BASE_IMAGE=developmentimage/plain_20.04:base # plain image with build_essentials installed
 # export WORKSPACE_BASE_IMAGE=developmentimage/plain_22.04_nogl:base # plain image with build_essentials installed
 # export WORKSPACE_BASE_IMAGE=developmentimage/ros2_foxy_20.04:base # image with ros2 foxy desktop installed
-# export WORKSPACE_BASE_IMAGE=developmentimage/ros2_humble_22.04:base # image with ros2 humble desktop installed
+# export WORKSPACE_BASE_IMAGE=developmentimage/ros2_humble_22.04_nogl:base # image with ros2 humble desktop installed
 
 # The Name of the Workspace image to use
 # you should add a workspace name folder and a image name


### PR DESCRIPTION
Hello,

added base image for ros2 humble on 22.04. 

You can test it using the commands:

```
source /opt/ros/humble/setup.bash
ros2 run demo_nodes_cpp talker

```
```
source /opt/ros/humble/setup.bash
ros2 run demo_nodes_py listener
```

Best,
Haider