### PR TITLE
Add colcon to ros2 dependencies

### DIFF
--- a/image_setup/01_base_images/install_ros2_dependencies.bash
+++ b/image_setup/01_base_images/install_ros2_dependencies.bash
@@ -25,6 +25,7 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-a
 
 apt update && apt upgrade -y &&  apt install -y \
     ros-$DISTRO-desktop \
+    python$vPYTHON-colcon-common-extensions \
     python$vPYTHON-rosdep \
     python$vPYTHON-rosinstall \
     python$vPYTHON-wstool


### PR DESCRIPTION
Adds `colcon-common-extensions` to ros2 dependencies. As colcon replaces catkin in ros2, it should be installed, as catkin is also included in the ros dependencies.