### PR TITLE
Disable version warnings for really outdated scripts (PRINT_INFO and SCRIPTSVERSION env not set at all)

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,4 @@
+4.0.2 - disable incompatibility warning for scriptless runs 
 4.0.1 - fix question behavior "renew" container for inital runs (always asked for renewal on 2nd run)
 4.0.0 - change exit behavior in container init to allow running without scripts
 3.0.0 - change devel/release users to dockeruser, split docker_commands and init testsuite

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,54 +1,18 @@
 version: '3.2'
 
+# example to run the devel image via docker-compose
+
 services:
-  neo4j:
-    image: neo4j:community
-    #container_name: neo4j
-    environment:
-      - NEO4J_AUTH=none
-    ports:
-       - "7474:7474"
-       - "7687:7687"
-    expose:
-      - "7474"
-      # - "7687"
-    networks:
-      cloud_slam_network:
-        # aliases:
-        #   - neo4j
+  hello_world_devel:
+    image: developmentimage/docker_image_development:devel
+    command: "hello_world"
+    #ports:
+    #  - "7890:7890"
+    #expose:
+    #  - "7890"
+    volumes:
+    # mount devel folders
+    - ./startscripts:/opt/startscripts
+    - ./workspace:/opt/workspace
+    - ./home:/home/dockeruser
 
-  redis:
-    image: redis
-    #container_name: redis
-    ports:
-      - "6379:6379"
-    expose:
-      - "6379"
-    networks:
-      cloud_slam_network:
-        # aliases:
-        #   - redis
-  
-  cloud_slam:
-    image: d-reg.hb.dfki.de/slam/cloud_slam:latest
-    environment:
-      - LISTEN_PORT=7890
-      - REDIS_IP=redis
-      - REDIS_PORT=6379
-      - NEO4J_IP=neo4j
-      - NEO4J_PORT=7474
-    depends_on:
-      - redis
-      - neo4j
-    restart: on-failure:10
-    #container_name: cloud_slam
-    ports:
-      - "7890:7890"
-    expose:
-      - "7890"
-    networks:
-      cloud_slam_network:
-
-
-networks:
-  cloud_slam_network:

--- a/image_setup/01_base_images/entrypoint.bash
+++ b/image_setup/01_base_images/entrypoint.bash
@@ -27,13 +27,8 @@ SCRIPTS_MAJOR=$(echo $SCRIPTSVERSION | awk -F'.' '{print $1}')
 SCRIPTS_MINOR=$(echo $SCRIPTSVERSION | awk -F'.' '{print $2}')
 SCRIPTS_PATCH=$(echo $SCRIPTSVERSION | awk -F'.' '{print $3}')
 
-# if SCRIPTSVERSION is not set at all, the scripts are too old (but compatible)
-if [ -z "$SCRIPTSVERSION" ]; then
-    $PRINT_WARNING
-    $PRINT_WARNING "WARNING: Your docker_image_development scripts are outdated, please pull your repo or merge a newer version from from https://github.com/dfki-ric/docker_image_development"
-    $PRINT_WARNING -e "\t* docker_image_developent Version checks disabled"
-    $PRINT_WARNING
-else
+# if SCRIPTSVERSION is not set at all expect "manual" run from command line/dockerfile etc, no version checks then
+if ! [ -z "$SCRIPTSVERSION" ]; then
     if [ "$IMAGEVERSION" != "$SCRIPTSVERSION" ]; then
         $PRINT_DEBUG "Scripts/Image version mismatch"
         # check major versions

--- a/image_setup/01_base_images/entrypoint.bash
+++ b/image_setup/01_base_images/entrypoint.bash
@@ -5,18 +5,6 @@
 #get HOST ip /sbin/ip route|awk '/default/ { print $3 }'
 
 
-# in clase of legacy scripts using new base images, set it here
-if [ -z "$PRINT_INFO" ]; then
-    # we expect that in info is neither "echo" or ":", nothing has been set
-    echo
-    echo "WARNING: Your docker_image_development scripts are outdated, please pull your repo or merge a newer version from https://github.com/dfki-ric/docker_image_development"
-    echo -e "\t* docker_image_developent verbosity levels are disabled for ouputs from the image, printing everything (as before)"
-    echo
-    export PRINT_DEBUG=echo
-    export PRINT_INFO=echo
-    export PRINT_WARNING=echo
-fi
-
 IMAGEVERSION=$(cat /opt/VERSION | head -n1 | awk -F' ' '{print $1}')
 #SCRIPTSVERSION provided via ENV in run command
 

--- a/image_setup/01_base_images/entrypoint.bash
+++ b/image_setup/01_base_images/entrypoint.bash
@@ -16,7 +16,7 @@ SCRIPTS_MINOR=$(echo $SCRIPTSVERSION | awk -F'.' '{print $2}')
 SCRIPTS_PATCH=$(echo $SCRIPTSVERSION | awk -F'.' '{print $3}')
 
 # if SCRIPTSVERSION is not set at all expect "manual" run from command line/dockerfile etc, no version checks then
-if ! [ -z "$SCRIPTSVERSION" ]; then
+if [ -n "$SCRIPTSVERSION" ]; then
     if [ "$IMAGEVERSION" != "$SCRIPTSVERSION" ]; then
         $PRINT_DEBUG "Scripts/Image version mismatch"
         # check major versions


### PR DESCRIPTION
In favour of no output when image is run without scripts.