### PR TITLE
list_ros_osdeps.bash only use apt deps

### DIFF
--- a/image_setup/02_devel_image/list_ros_osdeps.bash
+++ b/image_setup/02_devel_image/list_ros_osdeps.bash
@@ -7,4 +7,4 @@ if [ -z $ROS_DISTRO ]; then
     exit 13
 fi
 
-rosdep install --from-paths /opt/workspace/src --ignore-src --simulate --reinstall -r -y | awk '{print $6 " "}'
+rosdep install --from-paths /opt/workspace/src --ignore-src --simulate --reinstall -r -y | awk '$3 ~ /apt-get/ {print $6 " "}'


### PR DESCRIPTION
Solves: https://github.com/dfki-ric/docker_image_development/issues/97