### PR TITLE
WiP: profiling

### DIFF
--- a/.docker_scripts/docker_commands.bash
+++ b/.docker_scripts/docker_commands.bash
@@ -64,8 +64,18 @@ check_gpu(){
     fi
 }
 
+check_profiling(){
+    if [ "$MOUNT_CONTAINER_ROOT" = "true" ]; then
+        echo "need sudo rights to mount container root dir to $ROOT_DIR/container_root"
+        mkdir -p $ROOT_DIR/container_root
+        sudo bindfs /proc/$(docker inspect --format {{.State.Pid}} $CONTAINER_NAME)/root $ROOT_DIR/container_root
+    fi
+}
+
+
 init_docker(){
     check_gpu
+    check_profiling
 
     if "$INTERACTIVE"; then
         DOCKER_FLAGS="-ti"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 home
 workspace
+container_root
 .container_config.txt
 *.tar.gz
 /image_setup/01_base_images/VERSION

--- a/settings.bash
+++ b/settings.bash
@@ -109,4 +109,10 @@ export USE_XSERVER_VIA_SSH=false
 export NEEDS_DOCKER_IN_CONTAINER=false
 
 
+# To allow profiling with perf tools on the host, mount the container roor dir to a local folder (./container_root)
+# Then run profiling tools on the host, but provide root folder location to search for libs:
+# sudo hotspot --sysroot ./container_root
+# sudo perf record -o perf.data --call-graph dwarf --aio -z --pid $(pidof my_program) && perf report --symfs ./container_root
+# needs bindfs installed on the host
+export MOUNT_CONTAINER_ROOT=false
 


### PR DESCRIPTION
Trying to get perf/hotspot running:

There are two approaches:

* get hotspot running in the container (problem if kernel is newer that perf in the contianer)
* run perf outside container and get debug info out

Using bindfs the whole contianer ws can be mounted to the host, perf should be runnable with  --symfs= to point to the correct paths but it seems like is is not available

